### PR TITLE
fix(doc): Add escape property to cat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ module for right audio channel:
 ```
 "custom/wayves": {
     "format": "{}",
-    "exec": "python /PATH/TO/wayves/wayves.py -o cat -i cat -a cat"
+    "exec": "python /PATH/TO/wayves/wayves.py -o cat -i cat -a cat",
+    "escape": true,
 },
 
 ```

--- a/shared.py
+++ b/shared.py
@@ -19,7 +19,7 @@ def check_sound_and_player_status() -> (bool, bool):
     global player_name
 
     if player_name == "cava":
-        return True
+        return True, False
 
     try:
         status = get_status()


### PR DESCRIPTION
Since waybar will see `(=^ > ω <^=)` as a rich text mark like `<^ ...>`, we can add an escape property in config so these emotions can be displayed :)